### PR TITLE
File-typed control parameters: allow reading from another job

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,12 @@
 =======
 History
 =======
+2026.7.28: File-typed control parameters can reference another job
+   * A control parameter of type "file" can now reference another job's
+     file, via ``job://<job number>/<name>`` (SEAMM's ``Node.file_path``
+     gained read-only cross-job references) -- useful for pulling in a
+     file produced by an earlier, separate job.
+
 2025.5.7: Bugfix: Error printing lists of values
    * Fixed a problem printing variables that were a list of floats.
      

--- a/Makefile
+++ b/Makefile
@@ -104,3 +104,12 @@ install: uninstall ## install the package to the active Python's site-packages
 
 uninstall: clean ## uninstall the package
 	pip uninstall --yes $(MODULE)
+
+.PHONY: update
+update: ## post-release: sync main and dev, reinstall, run checks, push dev
+	git checkout main
+	git pull
+	git checkout dev
+	git merge --ff-only main
+	$(MAKE) lint install test
+	git push

--- a/control_parameters_step/control_parameters.py
+++ b/control_parameters_step/control_parameters.py
@@ -310,13 +310,13 @@ class ControlParameters(seamm.Node):
                             paths = []
                             tmp = []
                             for val in value:
-                                path = self.file_path(val)
+                                path = self.file_path(val, read_only=True)
                                 tmp.append(str(path))
                                 paths.append(path)
                             value = tmp
                             self.set_variable(dest, paths)
                         else:
-                            path = self.file_path(value)
+                            path = self.file_path(value, read_only=True)
                             value = str(path)
                             self.set_variable(dest, path)
                     else:
@@ -333,13 +333,13 @@ class ControlParameters(seamm.Node):
                         paths = []
                         tmp = []
                         for val in value:
-                            path = self.file_path(val)
+                            path = self.file_path(val, read_only=True)
                             tmp.append(str(path))
                             paths.append(path)
                         value = tmp
                         self.set_variable(dest, paths)
                     else:
-                        path = self.file_path(value)
+                        path = self.file_path(value, read_only=True)
                         value = str(path)
                         self.set_variable(dest, path)
                 else:

--- a/control_parameters_step/tk_control_parameters.py
+++ b/control_parameters_step/tk_control_parameters.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 """The graphical part of a Control Parameters step"""
+
 import json
 import shlex
 


### PR DESCRIPTION
## Summary
- File-typed control parameters can now reference another job's file, via `job://<job number>/<name>` -- useful for pulling in a file produced by an earlier, separate job. Built on `seamm`'s new `Node.file_path` cross-job support (companion PR: molssi-seamm/seamm#200).
- Also includes an incidental black reformat of `tk_control_parameters.py` (a blank line after the module docstring) and the previously-added `make update` target, neither yet in a release.

## Test plan
- [x] `make format lint install test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)